### PR TITLE
body_path missing from action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   body:
     description: 'Text describing the contents of the tag.'
     required: false
+  body_path:
+    description: 'Path to file with information about the tag.'
+    required: false
   draft:
     description: '`true` to create a draft (unpublished) release, `false` to create a published one. Default: `false`'
     required: false


### PR DESCRIPTION
The body_path input needed to be added to action.yml so the script could read it properly.